### PR TITLE
Update user datablock colors and sector list columns

### DIFF
--- a/Settings/ADRIA/ADRIA_SETTINGS_SYMB.txt
+++ b/Settings/ADRIA/ADRIA_SETTINGS_SYMB.txt
@@ -33,12 +33,12 @@ Datablock:even flight level:11974326:3.5:0:0:7
 Datablock:odd flight level:39835:3.5:0:0:7
 Datablock:arrivals:16776960:3.5:0:0:7
 Datablock:departures:30446:3.5:0:0:7
-Datablock:user 1:16777215:3.5:0:0:7
-Datablock:user 2:16777215:3.5:0:0:7
-Datablock:user 3:16777215:3.5:0:0:7
-Datablock:user 4:16777215:3.5:0:0:7
-Datablock:user 5:16777215:3.5:0:0:7
-Datablock:user 6:16777215:3.5:0:0:7
+Datablock:user 1:65280:3.8:0:0:7
+Datablock:user 2:38655:3.8:0:0:7
+Datablock:user 3:65280:3.8:0:0:7
+Datablock:user 4:16448000:3.8:0:0:7
+Datablock:user 5:16776960:3.8:0:0:7
+Datablock:user 6:33023:3.8:0:0:7
 Datablock:emergency:1645025:3.5:0:0:7
 Datablock:ongoing requested by me:11829985:3.5:0:0:7
 Datablock:ongoing requested by other:11829985:3.5:0:0:7

--- a/Settings/ADRIA_SETTINGS_PLUGINS.txt
+++ b/Settings/ADRIA_SETTINGS_PLUGINS.txt
@@ -251,7 +251,7 @@ TopSky plugin:ACList/SECTOR LIST/m_Column_5:COPX:5:0:10005:45:45:1:TopSky plugin
 TopSky plugin:ACList/SECTOR LIST/m_Column_6:ASSR:5:1:10041:62:62:1:TopSky plugin:TopSky plugin:TopSky plugin
 TopSky plugin:ACList/SECTOR LIST/m_Column_7:FCOPX:5:0:10045:45:45:1:TopSky plugin:TopSky plugin:TopSky plugin
 TopSky plugin:ACList/SECTOR LIST/m_Column_8:ADES:6:1:10008:1001:39:1:TopSky plugin:TopSky plugin:TopSky plugin
-TopSky plugin:ACList/SECTOR LIST/m_Column_9:STAR:15:0:10012:18:0:1:TopSky plugin::
+TopSky plugin:ACList/SECTOR LIST/m_Column_9:RWY:4:0:10010:19:0:1:TopSky plugin::
 VATAAssist:ACList/NEW LIST/m_Visible:0
 VATAAssist:ACList/NEW LIST/m_X:773
 VATAAssist:ACList/NEW LIST/m_Y:64
@@ -268,4 +268,5 @@ VATITA Controller Plugin:ACList/Mode S/m_Column_0:ARCID:9:1:9:0:0:1:::
 VATITA Controller Plugin:ACList/Mode S/m_Column_1:DIAS:6:1:901:202:951:1:VATITA Controller Plugin::
 VATITA Controller Plugin:ACList/Mode S/m_Column_2:DMACH:6:1:905:954:955:1:VATITA Controller Plugin::
 VATITA Controller Plugin:ACList/Mode S/m_Column_3:DHDG:4:1:125:0:0:1:VATITA Controller Plugin::
+TopSky plugin:ACList/Sector List/m_Column_10:STAR:15:0:10012:18:0:1:TopSky plugin::
 END

--- a/Settings/LYBA/LYBA_SETTINGS_SYMB.txt
+++ b/Settings/LYBA/LYBA_SETTINGS_SYMB.txt
@@ -33,12 +33,12 @@ Datablock:even flight level:11974326:3.5:0:0:7
 Datablock:odd flight level:39835:3.5:0:0:7
 Datablock:arrivals:16776960:3.5:0:0:7
 Datablock:departures:30446:3.5:0:0:7
-Datablock:user 1:16777215:3.5:0:0:7
-Datablock:user 2:16777215:3.5:0:0:7
-Datablock:user 3:16777215:3.5:0:0:7
-Datablock:user 4:16777215:3.5:0:0:7
-Datablock:user 5:16777215:3.5:0:0:7
-Datablock:user 6:16777215:3.5:0:0:7
+Datablock:user 1:65280:3.8:0:0:7
+Datablock:user 2:38655:3.8:0:0:7
+Datablock:user 3:65280:3.8:0:0:7
+Datablock:user 4:16448000:3.8:0:0:7
+Datablock:user 5:16776960:3.8:0:0:7
+Datablock:user 6:33023:3.8:0:0:7
 Datablock:emergency:1645025:3.5:0:0:7
 Datablock:ongoing requested by me:16776960:3.5:0:0:7
 Datablock:ongoing requested by other:16776960:3.5:0:0:7


### PR DESCRIPTION
Changed user datablock colors and sizes in ADRIA and LYBA settings for improved visibility. Modified ADRIA plugin settings to replace STAR with RWY in column 9 and added STAR to column 10.